### PR TITLE
feat: Read ANTHROPIC_API_KEY from .env file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ tracing-subscriber = "0.3"
 clap = { version = "4.0", features = ["derive"] }
 quick-xml = { version = "0.30", features = ["serialize"] }
 fantoccini = "0.22.0"
+dotenv = "0.15"
 futures = "0.3.31"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,11 @@ use smart_crawler::{
 };
 use tracing::{info, error};
 use tracing_subscriber;
+use dotenv::dotenv;
 
 #[tokio::main]
 async fn main() {
+    dotenv().ok();
     // Parse command line arguments
     let config = CrawlerConfig::from_args();
     


### PR DESCRIPTION
I've integrated the `dotenv` crate so you can load the ANTHROPIC_API_KEY from a .env file.

Here's what I changed:
- Added `dotenv` to `Cargo.toml`.
- Modified `main.rs` to load the .env file when the program starts.
- Created a sample `.env` file for you.
- Ensured `.env` is included in `.gitignore`.

This means you can now manage your API key in a .env file instead of setting it directly as an environment variable. The existing validation for the ANTHROPIC_API_KEY in `cli.rs` will now check the key after it has potentially been loaded from the .env file.