### PR TITLE
Refactor: Remove summary generation and display extracted data

### DIFF
--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -97,7 +97,6 @@ impl SmartCrawler {
                         selected_urls: Vec::new(),
                         scraped_content: Vec::new(),
                         analysis: vec![format!("Failed to crawl: {}", e)],
-                        summary: format!("Domain crawl failed: {}", e),
                     };
                     results.push(failed_result);
                 }
@@ -109,7 +108,6 @@ impl SmartCrawler {
             objective: self.config.objective.clone(),
             domains: final_domains,
             results,
-            overall_summary: "Overall summary generation removed.".to_string(),
         })
     }
 
@@ -219,7 +217,6 @@ impl SmartCrawler {
                 selected_urls: Vec::new(),
                 scraped_content: Vec::new(),
                 analysis: vec!["No relevant URLs selected by Claude".to_string()],
-                summary: "No relevant content found for the objective".to_string(),
             });
         }
 
@@ -277,7 +274,6 @@ impl SmartCrawler {
             selected_urls,
             scraped_content,
             analysis,
-            summary: "Domain summary generation removed.".to_string(),
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,13 +55,29 @@ async fn main() {
                 println!("\nDomain: {}", result.domain);
                 println!("URLs Selected: {}", result.selected_urls.len());
                 println!("Pages Scraped: {}", result.scraped_content.len());
-                println!("Summary: {}", result.summary);
+                println!("Analysis:");
+                for analysis_item in &result.analysis {
+                    println!("- {}", analysis_item);
+                }
+
+                println!("\n{:-^50}", " SCRAPED CONTENT DETAILS ");
+                if result.scraped_content.is_empty() {
+                    println!("No content scraped for this domain.");
+                } else {
+                    for (idx, content) in result.scraped_content.iter().enumerate() {
+                        println!("\n[{}] URL: {}", idx + 1, content.url);
+                        if let Some(title) = &content.title {
+                            println!("    Title: {}", title);
+                        }
+                        let snippet = content.text_content.chars().take(200).collect::<String>();
+                        println!("    Content Snippet: {}...", snippet);
+                        if idx < result.scraped_content.len() - 1 {
+                            println!("    {:-^40}", ""); // Separator between content items
+                        }
+                    }
+                }
                 println!("{:-^50}", "");
             }
-
-            println!("\n{:-^80}", " OVERALL SUMMARY ");
-            println!("{}", results.overall_summary);
-            println!("{:=^80}", "");
 
             // Save results if output file specified
             if let Err(e) = crawler.save_results(&results).await {


### PR DESCRIPTION
I removed the `generate_overall_summary` and `generate_domain_summary` functions from `SmartCrawler` in `src/crawler.rs`.

I updated `CrawlerResults` and `CrawlResult` structs in `src/crawler.rs` to remove the `overall_summary` and `summary` fields, respectively.

I modified `src/main.rs` to:
- Stop printing overall and per-domain summaries.
- Display the `analysis` field from each `CrawlResult`.
- Display details for each `ScrapedContent` item, including URL, title (if available), and a snippet of the text content.

This change addresses the issue of removing summaries and instead provides a view of the directly extracted information.