### PR TITLE
Refactor to use LLM trait for ClaudeClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ quick-xml = { version = "0.30", features = ["serialize"] }
 fantoccini = "0.22.0"
 dotenv = "0.15"
 futures = "0.3.31"
+async-trait = "0.1"

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -1,3 +1,5 @@
+use crate::llm::{LLM, LlmError}; // Import LLM trait and LlmError
+use async_trait::async_trait;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -17,13 +19,13 @@ pub enum ClaudeError {
     MissingApiKey,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)] // Added Clone
 pub struct ClaudeResponse {
     pub id: String,
     pub content: Vec<ContentBlock>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)] // Added Clone
 pub struct ContentBlock {
     #[serde(rename = "type")]
     pub content_type: String,
@@ -38,8 +40,7 @@ pub struct ClaudeClient {
 
 impl ClaudeClient {
     pub fn new() -> Result<Self, ClaudeError> {
-        let api_key = env::var("ANTHROPIC_API_KEY")
-            .map_err(|_| ClaudeError::MissingApiKey)?;
+        let api_key = env::var("ANTHROPIC_API_KEY").map_err(|_| ClaudeError::MissingApiKey)?;
 
         let client = Client::builder()
             .user_agent("Smart-Crawler/1.0")
@@ -49,20 +50,54 @@ impl ClaudeClient {
         Ok(Self { client, api_key })
     }
 
-    pub async fn select_urls<T>(
+    // This is the original send_message, renamed to avoid conflict with trait method
+    // and to keep its specific error type for internal calls.
+    async fn send_message_internal(&self, message: &str) -> Result<ClaudeResponse, ClaudeError> {
+        let payload = json!({
+            "model": "claude-3-haiku-20240307",
+            "max_tokens": 2000,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": message
+                }
+            ]
+        });
+
+        let response = self
+            .client
+            .post("https://api.anthropic.com/v1/messages")
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .json(&payload)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+            return Err(ClaudeError::ApiError(format!("API request failed: {}", error_text)));
+        }
+
+        let claude_response: ClaudeResponse = response.json().await?;
+        Ok(claude_response)
+    }
+}
+
+#[async_trait]
+impl LLM for ClaudeClient {
+    // Signature changed to match the updated LLM trait (urls: &[String])
+    async fn select_urls(
         &self,
         objective: &str,
-        urls: &[T],
+        urls: &[String], // Changed from urls: &[T]
         domain: &str,
         max_urls: usize,
-    ) -> Result<Vec<String>, ClaudeError>
-    where
-        T: AsRef<str>,
-    {
-        let url_list: Vec<String> = urls.iter()
-            .take(200) // Limit to avoid token limits
-            .map(|u| u.as_ref().to_string())
-            .collect();
+    ) -> Result<Vec<String>, LlmError> {
+        // url_list is now directly from the `urls` parameter.
+        // We clone it to own the data and be able to call .join() later.
+        // Also apply the take(200) limit like before.
+        let url_list: Vec<String> = urls.iter().take(200).cloned().collect();
 
         tracing::info!("URLs provided to Claude for selection: {:?}", url_list);
 
@@ -93,23 +128,26 @@ Return ONLY a JSON array of the selected URLs that exist in the provided list, n
             max_urls.min(20) // Conservative limit
         );
 
-        let response = self.send_message(&prompt).await?;
+        // Call the internal method that returns ClaudeError
+        let response = self.send_message_internal(&prompt).await
+            .map_err(|e| Box::new(e) as LlmError)?;
         
-        // Parse the JSON response
         let content = response.content.first()
-            .ok_or_else(|| ClaudeError::ApiError("No content in response".to_string()))?;
+            .ok_or_else(|| ClaudeError::ApiError("No content in response".to_string()))
+            .map_err(|e| Box::new(e) as LlmError)?;
 
-        let selected_urls: Vec<String> = serde_json::from_str(&content.text)
-            .map_err(|_| ClaudeError::ApiError("Failed to parse URL selection response".to_string()))?;
+        let selected_urls_from_llm: Vec<String> = serde_json::from_str(&content.text)
+            .map_err(|e| ClaudeError::JsonError(e)) // Map serde_json::Error to ClaudeError first
+            .map_err(|e| Box::new(e) as LlmError)?;
 
-        // Create a set of valid URLs for fast lookup
-        let valid_urls: HashSet<String> = url_list.into_iter().collect();
+        // Create a set of valid URLs for fast lookup (using the input `url_list` for validation)
+        let valid_urls_set: HashSet<String> = url_list.into_iter().collect();
         
         // Filter out any URLs that are not in the original list
-        let filtered_urls: Vec<String> = selected_urls
+        let filtered_urls: Vec<String> = selected_urls_from_llm
             .into_iter()
             .filter(|url| {
-                let is_valid = valid_urls.contains(url);
+                let is_valid = valid_urls_set.contains(url);
                 if !is_valid {
                     tracing::warn!("Claude returned URL not in original list, ignoring: {}", url);
                 }
@@ -120,12 +158,12 @@ Return ONLY a JSON array of the selected URLs that exist in the provided list, n
         Ok(filtered_urls)
     }
 
-    pub async fn analyze_content(
+    async fn analyze_content(
         &self,
         objective: &str,
         url: &str,
         content: &str,
-    ) -> Result<String, ClaudeError> {
+    ) -> Result<String, LlmError> {
         let prompt = format!(
             r#"You are analyzing web content for a specific objective.
 
@@ -143,45 +181,22 @@ Please analyze this content and extract information relevant to the objective. P
 Keep the response concise but informative."#,
             url,
             objective,
-            content.chars().take(8000).collect::<String>() // Limit content length
+            content.chars().take(8000).collect::<String>()
         );
 
-        let response = self.send_message(&prompt).await?;
+        let response = self.send_message_internal(&prompt).await
+            .map_err(|e| Box::new(e) as LlmError)?;
         
-        let content = response.content.first()
-            .ok_or_else(|| ClaudeError::ApiError("No content in response".to_string()))?;
+        let content_text = response.content.first()
+            .ok_or_else(|| ClaudeError::ApiError("No content in response".to_string()))
+            .map_err(|e| Box::new(e) as LlmError)?
+            .text.clone();
 
-        Ok(content.text.clone())
+        Ok(content_text)
     }
 
-    pub async fn send_message(&self, message: &str) -> Result<ClaudeResponse, ClaudeError> {
-        let payload = json!({
-            "model": "claude-3-haiku-20240307",
-            "max_tokens": 2000,
-            "messages": [
-                {
-                    "role": "user",
-                    "content": message
-                }
-            ]
-        });
-
-        let response = self
-            .client
-            .post("https://api.anthropic.com/v1/messages")
-            .header("x-api-key", &self.api_key)
-            .header("anthropic-version", "2023-06-01")
-            .header("content-type", "application/json")
-            .json(&payload)
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
-            return Err(ClaudeError::ApiError(format!("API request failed: {}", error_text)));
-        }
-
-        let claude_response: ClaudeResponse = response.json().await?;
-        Ok(claude_response)
+    async fn send_message(&self, message: &str) -> Result<ClaudeResponse, LlmError> {
+        self.send_message_internal(message).await
+            .map_err(|e| Box::new(e) as LlmError)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod cli;
 pub mod content;
 pub mod crawler;
 pub mod sitemap;
+pub mod llm;

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1,0 +1,34 @@
+use crate::claude::ClaudeResponse; // Assuming ClaudeResponse might be generalized later
+use async_trait::async_trait;
+
+/// Generic error type for LLM operations.
+pub type LlmError = Box<dyn std::error::Error + Send + Sync>;
+
+#[async_trait]
+pub trait LLM {
+    /// Selects the most relevant URLs from a given list based on an objective.
+    // Changed urls: &[T] to urls: &[String] to make the trait object-safe (dyn-compatible)
+    async fn select_urls(
+        &self,
+        objective: &str,
+        urls: &[String], // Changed from generic &[T]
+        domain: &str,
+        max_urls: usize,
+    ) -> Result<Vec<String>, LlmError>;
+
+    /// Analyzes web content for a specific objective.
+    async fn analyze_content(
+        &self,
+        objective: &str,
+        url: &str,
+        content: &str,
+    ) -> Result<String, LlmError>;
+
+    /// Sends a message to the LLM and gets a response.
+    /// Note: `ClaudeResponse` is used here. This might need generalization
+    /// if other LLMs have significantly different response structures.
+    async fn send_message(
+        &self,
+        message: &str,
+    ) -> Result<ClaudeResponse, LlmError>;
+}


### PR DESCRIPTION
Introduced an LLM trait with select_urls, analyze_content, and send_message methods. ClaudeClient now implements this LLM trait.
SmartCrawler is updated to use Arc<dyn LLM + Send + Sync>, making it more flexible for different LLM implementations.

This change allows for easier integration of other LLM providers in the future by implementing the LLM trait.