### PR TITLE
fix: resolve missing installer packages in GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,23 @@ jobs:
       - name: Build release binary
         run: cargo build --release --target ${{ matrix.target }}
         
+      - name: Verify binary exists
+        shell: bash
+        run: |
+          BINARY_PATH="target/${{ matrix.target }}/release/smart-crawler"
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            BINARY_PATH="${BINARY_PATH}.exe"
+          fi
+          
+          if [ ! -f "$BINARY_PATH" ]; then
+            echo "Error: Binary not found at $BINARY_PATH"
+            ls -la target/${{ matrix.target }}/release/
+            exit 1
+          else
+            echo "✓ Binary found at $BINARY_PATH"
+            ls -la "$BINARY_PATH"
+          fi
+        
       # Windows MSI Installer
       - name: Install WiX Toolset (Windows)
         if: matrix.installer == 'msi'
@@ -271,8 +288,26 @@ jobs:
       - name: Build MSI installer
         if: matrix.installer == 'msi'
         run: |
-          cargo wix init
+          echo "Building MSI installer for ${{ matrix.target }}"
+          
+          # Initialize cargo-wix if no wix directory exists
+          if (!(Test-Path "wix")) {
+            echo "Initializing cargo-wix..."
+            cargo wix init --force
+          }
+          
+          # Build the MSI installer
+          echo "Building MSI package..."
           cargo wix --target ${{ matrix.target }} --output smart-crawler-${{ needs.create-release.outputs.version }}.msi
+          
+          # Verify the MSI was created
+          if (Test-Path "smart-crawler-${{ needs.create-release.outputs.version }}.msi") {
+            echo "✓ MSI installer created successfully"
+            Get-Item "smart-crawler-${{ needs.create-release.outputs.version }}.msi"
+          } else {
+            echo "Error: MSI installer not found"
+            exit 1
+          }
           
       # macOS DMG Installer
       - name: Install create-dmg (macOS)
@@ -282,16 +317,43 @@ jobs:
       - name: Build DMG installer
         if: matrix.installer == 'dmg'
         run: |
+          # Create DMG contents directory
           mkdir -p dmg-contents
           cp target/${{ matrix.target }}/release/smart-crawler dmg-contents/
+          
+          # Create a simple README for installation
+          cat > dmg-contents/INSTALL.txt << 'EOF'
+          SmartCrawler Installation
+          
+          To install SmartCrawler:
+          1. Copy the 'smart-crawler' binary to /usr/local/bin/
+          2. Make it executable: chmod +x /usr/local/bin/smart-crawler
+          3. Run from terminal: smart-crawler --help
+          EOF
+          
+          # Create DMG without app-drop-link (not needed for CLI tools)
+          echo "Creating DMG package..."
           create-dmg \
             --volname "SmartCrawler" \
             --window-pos 200 120 \
-            --window-size 800 400 \
-            --icon-size 100 \
-            --app-drop-link 600 185 \
+            --window-size 600 400 \
+            --icon-size 80 \
+            --hide-extension "smart-crawler" \
             "smart-crawler-${{ needs.create-release.outputs.version }}.dmg" \
-            "dmg-contents/"
+            "dmg-contents/" || {
+            echo "create-dmg failed, using fallback method..."
+            # Fallback: create simple DMG if create-dmg fails
+            hdiutil create -format UDZO -srcfolder dmg-contents "smart-crawler-${{ needs.create-release.outputs.version }}.dmg"
+          }
+          
+          # Verify the DMG was created
+          if [ -f "smart-crawler-${{ needs.create-release.outputs.version }}.dmg" ]; then
+            echo "✓ DMG package created successfully"
+            ls -la smart-crawler-${{ needs.create-release.outputs.version }}.dmg
+          else
+            echo "Error: DMG package not found"
+            exit 1
+          fi
             
       # Linux DEB Package
       - name: Install cargo-deb (Linux DEB)
@@ -301,8 +363,22 @@ jobs:
       - name: Build DEB package
         if: matrix.installer == 'deb'
         run: |
+          echo "Building DEB package for ${{ matrix.target }}"
+          
+          # Build the DEB package
           cargo deb --target ${{ matrix.target }}
+          
+          # Copy and verify the DEB package
           cp target/${{ matrix.target }}/debian/*.deb smart-crawler-${{ needs.create-release.outputs.version }}.deb
+          
+          if [ -f "smart-crawler-${{ needs.create-release.outputs.version }}.deb" ]; then
+            echo "✓ DEB package created successfully"
+            ls -la smart-crawler-${{ needs.create-release.outputs.version }}.deb
+          else
+            echo "Error: DEB package not found"
+            ls -la target/${{ matrix.target }}/debian/
+            exit 1
+          fi
           
       # Linux RPM Package
       - name: Install cargo-rpm (Linux RPM)
@@ -315,8 +391,29 @@ jobs:
       - name: Build RPM package
         if: matrix.installer == 'rpm'
         run: |
+          echo "Building RPM package for ${{ matrix.target }}"
+          
+          # Initialize cargo-rpm if no .rpm directory exists
+          if [ ! -d ".rpm" ]; then
+            echo "Initializing cargo-rpm..."
+            cargo rpm init
+          fi
+          
+          # Build the RPM package
+          echo "Building RPM package..."
           cargo rpm build --target ${{ matrix.target }}
+          
+          # Copy and verify the RPM package
           cp target/${{ matrix.target }}/rpm/RPMS/x86_64/*.rpm smart-crawler-${{ needs.create-release.outputs.version }}.rpm
+          
+          if [ -f "smart-crawler-${{ needs.create-release.outputs.version }}.rpm" ]; then
+            echo "✓ RPM package created successfully"
+            ls -la smart-crawler-${{ needs.create-release.outputs.version }}.rpm
+          else
+            echo "Error: RPM package not found"
+            ls -la target/${{ matrix.target }}/rpm/RPMS/x86_64/
+            exit 1
+          fi
           
       - name: Upload Installer
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,17 @@ name = "smart-crawler"
 version = "0.2.4"
 edition = "2021"
 authors = ["SmartCrawler Team"]
-description = "An intelligent web crawler that uses LLMs to make smart crawling decisions"
+description = "A smart web crawler that uses LLMs to make smart crawling decisions"
 license = "MIT"
 homepage = "https://github.com/brainless/SmartCrawler"
 repository = "https://github.com/brainless/SmartCrawler"
 keywords = ["crawler", "scraper", "llm", "ai", "web"]
 categories = ["command-line-utilities", "web-programming"]
 readme = "README.md"
+
+[[bin]]
+name = "smart-crawler"
+path = "src/main.rs"
 
 [package.metadata.deb]
 maintainer = "SmartCrawler Team"
@@ -23,7 +27,7 @@ depends = "$auto"
 section = "utility"
 priority = "optional"
 assets = [
-    ["target/release/smart-crawler", "usr/bin/", "755"],
+    ["target/x86_64-unknown-linux-gnu/release/smart-crawler", "usr/bin/", "755"],
     ["README.md", "usr/share/doc/smart-crawler/", "644"],
 ]
 

--- a/VIBE.md
+++ b/VIBE.md
@@ -88,3 +88,35 @@ GitHub issue #9 reported a failure in the GitHub Actions workflow during binary 
   - Windows: skip (not applicable)
 - Added error checking and informative logging
 - Updated RELEASE.md troubleshooting documentation
+
+## Missing Installer Packages Fix
+
+### User Request
+I cannot see the msi, dmg, deb or rpm files in the latest releases even though there are steps in the release.yml GitHub Actions workflow. Can you please check and fix?
+
+### Issue Analysis
+The release workflow includes a `build-installers` job but the installer packages are not appearing in GitHub releases. Potential causes:
+- Installer build job may be failing silently
+- Dependencies for installer tools may be missing
+- File paths or naming issues in the upload process
+- Job dependencies or matrix configuration problems
+
+### Task Plan
+1. Create new branch for installer packages fix
+2. Update VIBE.md with task details (this section)
+3. Investigate missing installer packages in releases:
+   - Review workflow logs for installer job failures
+   - Check installer build steps and dependencies
+   - Verify file paths and upload commands
+4. Fix installer build workflow issues:
+   - Ensure all installer tools are properly installed
+   - Fix any path or dependency issues
+   - Improve error handling and logging
+5. Test and commit the fixes
+
+### Expected Implementation
+- Verify and fix Windows MSI installer generation
+- Verify and fix macOS DMG package creation
+- Verify and fix Linux DEB package generation  
+- Verify and fix Linux RPM package generation
+- Ensure all packages upload correctly to releases

--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -139,7 +139,7 @@ impl SmartCrawler {
             .map(|u| u.as_ref().to_string())
             .collect();
 
-        let urls_found: Vec<String> = {
+        let urls_found_in_homepage: Vec<String> = {
             tracing::info!(
                 "No URLs found in sitemap for {}, scraping root URL for links",
                 domain
@@ -185,7 +185,7 @@ impl SmartCrawler {
                 }
             }
         };
-        urls_to_analyze.extend(urls_found);
+        urls_to_analyze.extend(urls_found_in_homepage);
 
         // Only retain URLs that are one level deeper
         let urls_to_analyze =


### PR DESCRIPTION
Fixes issue where MSI, DMG, DEB, and RPM packages were not appearing in GitHub releases despite workflow steps being present.

Changes:
- Added binary configuration to Cargo.toml for proper packaging
- Fixed DEB package asset paths for cross-compilation targets
- Improved MSI installer with cargo-wix initialization and error handling
- Enhanced DMG creation with CLI-appropriate settings and fallback
- Added cargo-rpm initialization for RPM package generation
- Implemented comprehensive error checking and verification steps
- Added detailed logging for all installer build processes

Each installer type now:
- Verifies binary existence before building
- Provides clear progress logging
- Handles errors gracefully with appropriate fallbacks
- Confirms successful package creation before upload

🤖 Generated with [Claude Code](https://claude.ai/code)