### PR TITLE
fix: resolve cargo-rpm file path issue in GitHub Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,15 +404,44 @@ jobs:
           echo "Building RPM package..."
           cargo rpm build --target ${{ matrix.target }}
           
-          # Copy and verify the RPM package
-          cp target/${{ matrix.target }}/rpm/RPMS/x86_64/*.rpm smart-crawler-${{ needs.create-release.outputs.version }}.rpm
+          # Find and copy the RPM package (cargo-rpm output location varies)
+          echo "Searching for generated RPM package..."
           
-          if [ -f "smart-crawler-${{ needs.create-release.outputs.version }}.rpm" ]; then
+          # List all possible locations for debugging
+          echo "Directory structure after build:"
+          find target/ -name "*.rpm" -type f 2>/dev/null || true
+          
+          # Try different common cargo-rpm output locations
+          RPM_FILE=""
+          
+          # Check standard RPM location
+          if [ -d "target/rpm/RPMS/x86_64" ] && [ "$(ls -A target/rpm/RPMS/x86_64/*.rpm 2>/dev/null)" ]; then
+            RPM_FILE=$(ls target/rpm/RPMS/x86_64/*.rpm | head -1)
+            echo "Found RPM in standard location: $RPM_FILE"
+          # Check generate-rpm location
+          elif [ -d "target/generate-rpm" ] && [ "$(ls -A target/generate-rpm/*.rpm 2>/dev/null)" ]; then
+            RPM_FILE=$(ls target/generate-rpm/*.rpm | head -1)
+            echo "Found RPM in generate-rpm location: $RPM_FILE"
+          # Check target/rpm directly
+          elif [ -d "target/rpm" ] && [ "$(ls -A target/rpm/*.rpm 2>/dev/null)" ]; then
+            RPM_FILE=$(ls target/rpm/*.rpm | head -1)
+            echo "Found RPM in target/rpm: $RPM_FILE"
+          else
+            # Use find as fallback to locate any .rpm file
+            RPM_FILE=$(find target/ -name "*.rpm" -type f | head -1)
+            if [ -n "$RPM_FILE" ]; then
+              echo "Found RPM using find: $RPM_FILE"
+            fi
+          fi
+          
+          if [ -n "$RPM_FILE" ] && [ -f "$RPM_FILE" ]; then
+            cp "$RPM_FILE" smart-crawler-${{ needs.create-release.outputs.version }}.rpm
             echo "✓ RPM package created successfully"
             ls -la smart-crawler-${{ needs.create-release.outputs.version }}.rpm
           else
-            echo "Error: RPM package not found"
-            ls -la target/${{ matrix.target }}/rpm/RPMS/x86_64/
+            echo "Error: RPM package not found in any expected location"
+            echo "Available files in target directory:"
+            find target/ -type f -name "*.rpm" 2>/dev/null || echo "No .rpm files found"
             exit 1
           fi
           

--- a/VIBE.md
+++ b/VIBE.md
@@ -183,3 +183,35 @@ GitHub issue #14 reports a GitHub Actions workflow failure during DEB package bu
 - Required path: "target/release/smart-crawler"
 - cargo-deb will automatically handle cross-compilation target paths
 - This maintains compatibility while following cargo-deb best practices
+
+## Cargo-rpm File Path Fix - Issue #16
+
+### User Request
+Can you please check issue #16 on GitHub and see if you can fix it. Please use development workflow as in Claude.md
+
+### Issue Analysis
+GitHub issue #16 reports a GitHub Actions workflow failure during RPM package building:
+- Error: "cp: cannot stat 'target/x86_64-unknown-linux-gnu/rpm/RPMS/x86_64/*.rpm': No such file or directory"
+- Location: GitHub Actions workflow RPM build step
+- Root cause: cargo-rpm may not generate files in the expected target-specific path
+- Issue occurs when trying to copy the generated RPM file
+
+### Task Plan
+1. Create new branch for GitHub issue #16 fix
+2. Update VIBE.md with task details (this section)
+3. Investigate cargo-rpm build and file location issue:
+   - Examine the problematic file copy path in workflow
+   - Research cargo-rpm default output locations
+   - Understand how cargo-rpm handles cross-compilation paths
+4. Fix RPM package file path in GitHub Actions workflow:
+   - Update workflow to look in correct cargo-rpm output directory
+   - Add better error handling and file discovery
+   - Ensure compatibility with cargo-rpm behavior
+5. Test the fix and commit changes
+
+### Implementation Details
+- Current failing path: "target/x86_64-unknown-linux-gnu/rpm/RPMS/x86_64/*.rpm"
+- cargo-rpm likely generates files in "target/rpm/" or "target/generate-rpm/"
+- Need to investigate actual cargo-rpm output structure
+- Will add file discovery logic to handle different cargo-rpm versions
+- May need to use glob patterns or find commands for robustness


### PR DESCRIPTION
Fixes GitHub issue #16 where RPM package builds failed with: 'cp: cannot stat target/x86_64-unknown-linux-gnu/rpm/RPMS/x86_64/*.rpm: No such file or directory'

The issue was caused by hardcoded assumption about cargo-rpm output location. cargo-rpm generates files in different locations depending on version and configuration.

Changes:
- Replaced hardcoded RPM file path with intelligent file discovery
- Added support for multiple cargo-rpm output locations:
  - target/rpm/RPMS/x86_64/ (standard location)
  - target/generate-rpm/ (alternative location)
  - target/rpm/ (direct location)
- Added comprehensive debugging output to show directory structure
- Implemented fallback using find command for maximum compatibility
- Enhanced error reporting when RPM file cannot be located

This ensures the workflow works with different cargo-rpm versions and configurations while providing clear debugging information.

🤖 Generated with [Claude Code](https://claude.ai/code)