### PR TITLE
feat: implement alternative HTML extraction with tree structure (issue #44)

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -115,6 +115,7 @@ impl Browser {
             links,
             meta_description: Some(meta_description),
             headings,
+            alternative_extraction: None,
         })
     }
 


### PR DESCRIPTION
## Summary
- Implements alternative data extraction approach as specified in issue #44
- Adds new `--extract` CLI option for single URL tree extraction
- Creates HTML tree structure without cleaning raw HTML first
- Displays tree with ASCII characters showing element tags, IDs, and classes

## Features
- **New CLI Option**: `--extract <URL>` for alternative tree extraction
- **Tree Structure**: `HtmlTreeNode` representing DOM as hierarchical tree
- **ASCII Display**: Clean tree visualization with element attributes
- **Smart Filtering**: Ignores images, media, SVG elements, and control characters  
- **Class Filtering**: Removes transient classes like "active", "highlighted", "selected"
- **Paragraph Merging**: Combines sibling paragraph tags under same parent container

## Implementation Details
- Bypasses existing HTML cleaning pipeline for raw extraction
- Preserves order of sibling elements as encountered in DOM
- Extracts direct text content only (not from child elements)
- Follows all rules specified in issue #44 for tag filtering and content handling

## Test plan
- [x] Build and compile successfully
- [x] CLI help shows new --extract option
- [x] Code passes clippy and fmt checks
- [ ] Test with various HTML structures
- [ ] Verify ASCII tree output format
- [ ] Test URL validation and error handling

🤖 Generated with [Claude Code](https://claude.ai/code)