### PR TITLE
feat: implement data extraction mode with --extract CLI option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,7 @@ pub struct CrawlerConfig {
     pub verbose: bool,
     pub url_ranking_config: UrlRankingConfig,
     pub enable_keyword_filtering: bool,
+    pub extract_mode: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -131,6 +132,12 @@ impl CrawlerConfig {
                     .help("Multiplier for candidate URLs sent to LLM (candidate_count = max_urls * multiplier)")
                     .default_value("3")
             )
+            .arg(
+                Arg::new("extract")
+                    .long("extract")
+                    .help("Enable data extraction mode - extract structured tree data from HTML")
+                    .action(clap::ArgAction::SetTrue)
+            )
             .get_matches();
 
         let verbose = matches.get_flag("verbose");
@@ -215,6 +222,8 @@ impl CrawlerConfig {
             ..UrlRankingConfig::default()
         };
 
+        let extract_mode = matches.get_flag("extract");
+
         AppMode::Crawl(CrawlerConfig {
             objective,
             domains: Arc::new(Mutex::new(domains)),
@@ -225,6 +234,7 @@ impl CrawlerConfig {
             verbose,
             url_ranking_config,
             enable_keyword_filtering,
+            extract_mode,
         })
     }
 }

--- a/src/content.rs
+++ b/src/content.rs
@@ -10,6 +10,15 @@ pub struct Item {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractionNode {
+    pub tag: String,
+    pub id: Option<String>,
+    pub classes: Vec<String>,
+    pub text: Option<String>,
+    pub children: Vec<ExtractionNode>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScrapedWebPage {
     pub url: String,
     pub title: Option<String>,
@@ -17,4 +26,5 @@ pub struct ScrapedWebPage {
     pub links: Vec<String>,
     pub meta_description: Option<String>,
     pub headings: Vec<String>,
+    pub extraction_data: Option<ExtractionNode>,
 }

--- a/src/crawler.rs
+++ b/src/crawler.rs
@@ -239,7 +239,10 @@ impl SmartCrawler {
 
         // Analyze starting URLs
         for start_url in &starting_urls {
-            match browser.scrape_url(start_url).await {
+            match browser
+                .scrape_url_with_extraction(start_url, self.config.extract_mode)
+                .await
+            {
                 Ok(web_page) => {
                     tracing::info!("Successfully scraped starting URL: {}", web_page.url);
 
@@ -486,7 +489,10 @@ impl SmartCrawler {
                 }
             }
 
-            match browser.scrape_url(url).await {
+            match browser
+                .scrape_url_with_extraction(url, self.config.extract_mode)
+                .await
+            {
                 Ok(web_page) => {
                     tracing::info!("Analyzing content from: {}", web_page.url);
 
@@ -653,7 +659,10 @@ impl SmartCrawler {
             }
 
             tracing::info!("Scraping URL: {}", url);
-            match browser.scrape_url(url).await {
+            match browser
+                .scrape_url_with_extraction(url, self.config.extract_mode)
+                .await
+            {
                 Ok(web_page) => {
                     tracing::info!("Successfully scraped: {}", web_page.url);
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -1,0 +1,252 @@
+use crate::content::ExtractionNode;
+use scraper::{ElementRef, Html, Node};
+use std::collections::HashSet;
+
+pub struct HtmlExtractor {
+    ignored_tags: HashSet<String>,
+    ignored_classes: HashSet<String>,
+}
+
+impl HtmlExtractor {
+    pub fn new() -> Self {
+        let mut ignored_tags = HashSet::new();
+        ignored_tags.insert("script".to_string());
+        ignored_tags.insert("style".to_string());
+        ignored_tags.insert("meta".to_string());
+        ignored_tags.insert("link".to_string());
+        ignored_tags.insert("noscript".to_string());
+        ignored_tags.insert("title".to_string());
+        ignored_tags.insert("head".to_string());
+        ignored_tags.insert("img".to_string());
+        ignored_tags.insert("video".to_string());
+        ignored_tags.insert("audio".to_string());
+        ignored_tags.insert("svg".to_string());
+        ignored_tags.insert("path".to_string());
+        ignored_tags.insert("iframe".to_string());
+        ignored_tags.insert("embed".to_string());
+        ignored_tags.insert("object".to_string());
+
+        let mut ignored_classes = HashSet::new();
+        ignored_classes.insert("active".to_string());
+        ignored_classes.insert("highlighted".to_string());
+        ignored_classes.insert("selected".to_string());
+
+        Self {
+            ignored_tags,
+            ignored_classes,
+        }
+    }
+
+    pub fn extract(&self, html: &str) -> Option<ExtractionNode> {
+        let document = Html::parse_document(html);
+
+        // Find the root element (usually html or body)
+        let root = document.root_element();
+        self.process_element(&root)
+    }
+
+    fn process_element(&self, element: &ElementRef) -> Option<ExtractionNode> {
+        let tag_name = element.value().name().to_lowercase();
+
+        // Apply tag filtering rules
+        if self.should_ignore_tag(&tag_name) {
+            return None;
+        }
+
+        // Get element attributes
+        let id = self.process_id_attribute(element);
+        let classes = self.process_class_attribute(element);
+
+        // Get direct text content (not from children)
+        let direct_text = self.extract_direct_text(element);
+
+        // Process children
+        let mut children = Vec::new();
+        for child in element.children() {
+            if let Some(child_element) = ElementRef::wrap(child) {
+                if let Some(child_node) = self.process_element(&child_element) {
+                    children.push(child_node);
+                }
+            }
+        }
+
+        // Apply text rules - merge sibling paragraphs if needed
+        let children = self.merge_sibling_paragraphs(children);
+
+        // Check if element should be ignored due to emptiness
+        if self.should_ignore_empty_element(&direct_text, &children) {
+            return None;
+        }
+
+        Some(ExtractionNode {
+            tag: tag_name,
+            id,
+            classes,
+            text: direct_text,
+            children,
+        })
+    }
+
+    fn should_ignore_tag(&self, tag: &str) -> bool {
+        self.ignored_tags.contains(tag)
+    }
+
+    fn should_ignore_empty_element(
+        &self,
+        text: &Option<String>,
+        children: &[ExtractionNode],
+    ) -> bool {
+        // Ignore if no text and no children
+        if text.is_none() && children.is_empty() {
+            return true;
+        }
+
+        // Ignore if text only contains control/special characters
+        if let Some(text_content) = text {
+            if text_content
+                .chars()
+                .all(|c| c.is_control() || c.is_whitespace())
+            {
+                return children.is_empty();
+            }
+        }
+
+        false
+    }
+
+    fn process_id_attribute(&self, element: &ElementRef) -> Option<String> {
+        element
+            .value()
+            .attr("id")
+            .map(|id| id.trim().to_string())
+            .filter(|id| !id.is_empty())
+    }
+
+    fn process_class_attribute(&self, element: &ElementRef) -> Vec<String> {
+        element
+            .value()
+            .attr("class")
+            .map(|classes| {
+                classes
+                    .split_whitespace()
+                    .map(|class| class.trim().to_string())
+                    .filter(|class| !class.is_empty() && !self.ignored_classes.contains(class))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn extract_direct_text(&self, element: &ElementRef) -> Option<String> {
+        let mut direct_text = String::new();
+
+        for child in element.children() {
+            if let Node::Text(text_node) = child.value() {
+                direct_text.push_str(text_node.text.as_ref());
+            }
+        }
+
+        let trimmed = direct_text.trim().to_string();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed)
+        }
+    }
+
+    fn merge_sibling_paragraphs(&self, children: Vec<ExtractionNode>) -> Vec<ExtractionNode> {
+        if children.len() < 2 {
+            return children;
+        }
+
+        let mut merged = Vec::new();
+        let mut i = 0;
+
+        while i < children.len() {
+            let mut current = children[i].clone();
+
+            // Check if current element is a paragraph and has text
+            if current.tag == "p" && current.text.is_some() {
+                let mut merged_text = current.text.clone().unwrap_or_default();
+                let mut j = i + 1;
+
+                // Look for consecutive paragraph siblings
+                while j < children.len() && children[j].tag == "p" && children[j].text.is_some() {
+                    if !merged_text.is_empty() {
+                        merged_text.push(' ');
+                    }
+                    merged_text.push_str(children[j].text.as_ref().unwrap());
+                    j += 1;
+                }
+
+                // If we merged paragraphs, update the current node
+                if j > i + 1 {
+                    current.text = Some(merged_text);
+                    i = j;
+                } else {
+                    i += 1;
+                }
+            } else {
+                i += 1;
+            }
+
+            merged.push(current);
+        }
+
+        merged
+    }
+
+    pub fn print_tree(&self, node: &ExtractionNode) {
+        self.print_tree_recursive(node, 0, true);
+    }
+
+    fn print_tree_recursive(&self, node: &ExtractionNode, depth: usize, is_last: bool) {
+        // Create tree line prefix
+        let mut prefix = String::new();
+        for i in 0..depth {
+            if i == depth - 1 {
+                if is_last {
+                    prefix.push_str("└── ");
+                } else {
+                    prefix.push_str("├── ");
+                }
+            } else {
+                prefix.push_str("│   ");
+            }
+        }
+
+        // Build element display string
+        let mut display = format!("{}{}", prefix, node.tag);
+
+        if let Some(id) = &node.id {
+            display.push_str(&format!(" id=\"{id}\""));
+        }
+
+        if !node.classes.is_empty() {
+            display.push_str(&format!(" class=\"{}\"", node.classes.join(" ")));
+        }
+
+        if let Some(text) = &node.text {
+            // Truncate long text for display
+            let truncated = if text.len() > 50 {
+                format!("{}...", &text[..47])
+            } else {
+                text.clone()
+            };
+            display.push_str(&format!(" [{truncated}]"));
+        }
+
+        println!("{display}");
+
+        // Print children
+        for (i, child) in node.children.iter().enumerate() {
+            let is_last_child = i == node.children.len() - 1;
+            self.print_tree_recursive(child, depth + 1, is_last_child);
+        }
+    }
+}
+
+impl Default for HtmlExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -196,10 +196,10 @@ impl HtmlExtractor {
     }
 
     pub fn print_tree(&self, node: &ExtractionNode) {
-        self.print_tree_recursive(node, 0, true);
+        Self::print_tree_recursive(node, 0, true);
     }
 
-    fn print_tree_recursive(&self, node: &ExtractionNode, depth: usize, is_last: bool) {
+    fn print_tree_recursive(node: &ExtractionNode, depth: usize, is_last: bool) {
         // Create tree line prefix
         let mut prefix = String::new();
         for i in 0..depth {
@@ -240,7 +240,7 @@ impl HtmlExtractor {
         // Print children
         for (i, child) in node.children.iter().enumerate() {
             let is_last_child = i == node.children.len() - 1;
-            self.print_tree_recursive(child, depth + 1, is_last_child);
+            Self::print_tree_recursive(child, depth + 1, is_last_child);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod content;
 pub mod crawler;
 pub mod entities;
+pub mod extractor;
 pub mod generate_ts;
 pub mod llm;
 pub mod sitemap;


### PR DESCRIPTION
- Add --extract CLI flag to enable data extraction mode
- Create ExtractionNode tree structure for HTML element representation
- Implement HtmlExtractor with configurable rules for tag/class filtering
- Add tree traversal that preserves element order and extracts text content
- Support ASCII tree output with element tags, IDs, and classes
- Apply filtering rules for script/style/meta tags and dynamic classes
- Merge consecutive paragraph elements under same parent containers
- Integrate extraction into crawler flow when --extract mode enabled

🤖 Generated with [Claude Code](https://claude.ai/code)